### PR TITLE
Ensure pandas 2.0 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2.1.1

--- a/suncalc/suncalc.py
+++ b/suncalc/suncalc.py
@@ -69,7 +69,7 @@ def to_milliseconds(date):
     # Pandas series of Pandas datetime objects
     if pd and pd.api.types.is_datetime64_any_dtype(date):
         # A datetime-like series coerce to int is (always?) in nanoseconds
-        return date.astype(int) / 10 ** 6
+        return date.astype('int64') / 10 ** 6
 
     # Single pandas Timestamp
     if pd and isinstance(date, pd.Timestamp):
@@ -77,11 +77,11 @@ def to_milliseconds(date):
 
     # Numpy datetime64
     if np.issubdtype(date.dtype, np.datetime64):
-        return date.astype('datetime64[ms]').astype('int')
+        return date.astype('datetime64[ms]').astype('int64')
 
     # Last-ditch effort
     if pd:
-        return np.array(pd.to_datetime(date).astype(int) / 10 ** 6)
+        return np.array(pd.to_datetime(date).astype('int64') / 10 ** 6)
 
     raise ValueError(f'Unknown date type: {type(date)}')
 


### PR DESCRIPTION
This PR ensures compatibility with pandas 2.0.

In later versions of pandas, when converting a datetime type to epoch millis, one must explicitly specify the target dtype, `int` won't suffice. Tests before this PR fail on my Windows machine with the following error:
```python
TypeError: Converting from datetime64[ns, UTC] to int32 is not supported. Do obj.astype('int64').astype(dtype) instead
```
So I explicitly state `int64` as the conversion target.
