### PR TITLE
Bump version: 0.1.2 → 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.3] - 2023-04-18
+
+- Ensure pandas 2.0 compatibility (fix integer casting of datetimes)
+
 ## [0.1.2] - 2020-12-02
 
 - Try to catch NaN before passing to `datetime.utcfromtimestamp`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     description="A fast, vectorized Python port of suncalc.js",
     install_requires=requirements,
@@ -44,6 +46,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/kylebarron/suncalc-py',
-    version='0.1.2',
+    version='0.1.3',
     zip_safe=False,
 )

--- a/suncalc/__init__.py
+++ b/suncalc/__init__.py
@@ -1,5 +1,5 @@
 __author__ = """Kyle Barron"""
 __email__ = 'kylebarron2@gmail.com'
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 from .suncalc import get_position, get_times


### PR DESCRIPTION
This PR bumps package version to `0.1.3`. Support is added in `setup.py` for Python versions `3.10` and `3.11`.